### PR TITLE
Start a dataset description for BIDS compliance

### DIFF
--- a/datalad_description.json
+++ b/datalad_description.json
@@ -1,0 +1,30 @@
+{
+  "Name": "studyforrest structural data",
+  "BIDSVersion": "TODO",
+  "DatasetType": "raw",
+  "License": "CC0",
+  "Authors": [
+        "Michael Hanke",
+        "Falko R. Kaule",
+        "Ayan Sengupta",
+        "Florian J. Baumgartner",
+        "J. Swaroop Guntupalli",
+        "Christian Häusler",
+        "Michael Hoffmann",
+        "Vittorio Iacovella",
+        "Daniel Kottke",
+        "Jörg Stadler"
+  ],
+  "Acknowledgements": "Only open-source software was employed in this study. We thank their respective authors for making it publicly available.",
+  "HowToAcknowledge": "Please follow good scientific practice by citing the most appropriate publication(s) describing the aspects of this datasets that were used in a study.",
+  "Funding": [
+    "We acknowledge the support of the Combinatorial NeuroImaging Core Facility at the Leibniz Institute for Neurobiology in Magdeburg, and the German federal state of Saxony-Anhalt, Project: Center for Behavioral Brain Sciences. This research was, in part, also supported by the German Federal Ministry of Education and Research (BMBF) as part of a US-German collaboration in computational neuroscience (CRCNS), co-funded by the BMBF and the US National Science Foundation (BMBF 01GQ1112; NSF 1129855). Work on the data-sharing technology employed for this research was supported by US-German CRCNS project, co-funded by the BMBF and the US National Science Foundation (BMBF 01GQ1411; NSF 1429999)."
+  ],
+  "EthicsApprovals": [
+    "Army Human Research Protections Office (Protocol ARL-20098-10051, ARL 12-040, and ARL 12-041)"
+  ],
+  "ReferencesAndLinks": [
+    "http://studyforrest.org"
+  ],
+  "DatasetDOI": "TODO"
+}

--- a/datalad_description.json
+++ b/datalad_description.json
@@ -2,7 +2,7 @@
   "Name": "studyforrest structural data",
   "BIDSVersion": "TODO",
   "DatasetType": "raw",
-  "License": "CC0",
+  "License": "PDDL",
   "Authors": [
         "Michael Hanke",
         "Falko R. Kaule",


### PR DESCRIPTION
Could become a fix to #3 and https://github.com/psychoinformatics-de/studyforrest-data/issues/13

It yet lacks:
- specification of BIDS version (to be determined, and potentially dependent on potential other BIDSification/maintenance efforts)
- DOI (optional, but possible given that a publication to GIN is planned)