### PR TITLE
Remove wrong Ethics approval information, fixes #8

### DIFF
--- a/dataset_description.json
+++ b/dataset_description.json
@@ -20,9 +20,6 @@
   "Funding": [
     "We acknowledge the support of the Combinatorial NeuroImaging Core Facility at the Leibniz Institute for Neurobiology in Magdeburg, and the German federal state of Saxony-Anhalt, Project: Center for Behavioral Brain Sciences. This research was, in part, also supported by the German Federal Ministry of Education and Research (BMBF) as part of a US-German collaboration in computational neuroscience (CRCNS), co-funded by the BMBF and the US National Science Foundation (BMBF 01GQ1112; NSF 1129855). Work on the data-sharing technology employed for this research was supported by US-German CRCNS project, co-funded by the BMBF and the US National Science Foundation (BMBF 01GQ1411; NSF 1429999)."
   ],
-  "EthicsApprovals": [
-    "Army Human Research Protections Office (Protocol ARL-20098-10051, ARL 12-040, and ARL 12-041)"
-  ],
   "ReferencesAndLinks": [
     "http://studyforrest.org"
   ],


### PR DESCRIPTION
The ``EthicsApprovals`` field is Optional in BIDS, and I couldn't find actual ethics approval information in https://openneuro.org/datasets/ds000113/versions/1.3.0/file-display/dataset_description.json or https://github.com/psychoinformatics-de/studyforrest-data-phase2/blob/master/dataset_description.json.

Ping @mih @loj.